### PR TITLE
Improve logging and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ the available package manager to install `rkhunter`, `chkrootkit`, `lynis`,
 `maldet` and `ossec-hids` along with the Python modules from
 `requirements.txt`.
 
+All detections from the Python heuristics are automatically sent to syslog via
+the `logger` command using the tag `sentinelroot`.  Messages can be inspected
+with `dmesg` or in `/var/log/syslog`.
+
 ```bash
 sudo ./install.sh
 ```
@@ -72,7 +76,7 @@ When run as root the script copies `sentinelroot` to `/usr/local/bin` and enable
 
 ## External Scanner Integration
 
-On its first execution the Python module attempts to run `rkhunter`, `chkrootkit`, `lynis`, `maldet` and the OSSEC rootcheck when these tools are installed. Output from these scanners is sent to syslog via the `logger` command and can be reviewed with `dmesg` or by inspecting `/var/log/syslog`.
+On its first execution the Python module attempts to run [rkhunter](http://rkhunter.sourceforge.net/), [chkrootkit](http://www.chkrootkit.org/), [lynis](https://cisofy.com/lynis/), [maldet](https://www.rfxn.com/projects/linux-malware-detect/) and the [OSSEC](https://www.ossec.net/) rootcheck when these tools are installed. Output from these scanners is sent to syslog via the `logger` command and can be reviewed with `dmesg` or by inspecting `/var/log/syslog`.
 
 ## Training the ML Heuristic
 

--- a/sentinelroot/sentinel.py
+++ b/sentinelroot/sentinel.py
@@ -21,6 +21,8 @@ EVIL_PROCESS_SIGNATURES.extend(load_signatures())
 EVIL_MODULE_SIGNATURES = ["evilmod", "badmodule"]
 import shutil
 
+LOG_TAG = "sentinelroot"
+
 @dataclass
 class DetectionResult:
     issue: str
@@ -31,7 +33,12 @@ class SentinelReport:
     results: List[DetectionResult] = field(default_factory=list)
 
     def add(self, issue: str, details: str):
+        message = f"{issue}: {details}"
         self.results.append(DetectionResult(issue, details))
+        try:
+            subprocess.run(["logger", "-t", LOG_TAG, message], check=False)
+        except Exception:
+            pass
 
     def summary(self) -> str:
         return "\n".join(f"{r.issue}: {r.details}" for r in self.results)


### PR DESCRIPTION
## Summary
- log every detected issue with logger via `sentinelroot` tag
- document syslog usage in README
- link to external scanner homepages

## Testing
- `python -m compileall sentinelroot`
- `cc -O2 -Wall -o build/sentinelroot src/sentinel.c`
- `python -m sentinelroot.sentinel`

------
https://chatgpt.com/codex/tasks/task_e_684590670928832394b5251b358ed120