### PR TITLE
Add boot integrity service

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ A C implementation replicates the heuristic checks and logs results to syslog. B
 ```
 
 When run as root the script copies `sentinelroot` to `/usr/local/bin` and enables a `sentinelroot` systemd service.
+The installation also deploys `sentinelboot`, which verifies the contents of
+`/boot` on every startup and restores any modified files from a database.
 
 ## External Scanner Integration
 

--- a/install.sh
+++ b/install.sh
@@ -23,9 +23,12 @@ mkdir -p build
 cc -O2 -Wall -o build/sentinelroot src/sentinel.c
 if [ "$(id -u)" = "0" ]; then
     install -m 755 build/sentinelroot /usr/local/bin/
+    install -m 755 sentinelroot/boot_protect.py /usr/local/bin/sentinelboot
     install -m 644 sentinelroot.service /etc/systemd/system/
+    install -m 644 sentinelboot.service /etc/systemd/system/
     systemctl daemon-reload
     systemctl enable sentinelroot.service
+    systemctl enable sentinelboot.service
     echo "Installed sentinelroot and enabled service"
 else
     echo "Build finished. Run as root to install and enable the service."

--- a/sentinelboot.service
+++ b/sentinelboot.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Sentinel Boot Protection
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/sentinelboot
+
+[Install]
+WantedBy=multi-user.target
+

--- a/sentinelroot/boot_protect.py
+++ b/sentinelroot/boot_protect.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Boot partition integrity checker.
+
+On first run this script backs up files from /boot into a sqlite database
+as base64 encoded blobs. On subsequent runs it verifies the checksums of
+those files and restores any that changed using ``dd``.
+"""
+import os
+import sqlite3
+import base64
+import hashlib
+import subprocess
+from pathlib import Path
+
+BOOT_DB = os.path.join(os.path.dirname(__file__), 'boot_files.db')
+BOOT_DIR = '/boot'
+
+
+def init_boot_db(db_path: str = BOOT_DB) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    c = conn.cursor()
+    c.execute(
+        """CREATE TABLE IF NOT EXISTS boot_files (
+            path TEXT PRIMARY KEY,
+            checksum TEXT,
+            data TEXT
+        )"""
+    )
+    conn.commit()
+    return conn
+
+
+def sha256_data(data: bytes) -> str:
+    h = hashlib.sha256()
+    h.update(data)
+    return h.hexdigest()
+
+
+def sha256_file(path: str) -> str:
+    try:
+        with open(path, 'rb') as f:
+            return sha256_data(f.read())
+    except Exception:
+        return ''
+
+
+def backup_boot_files(root: str = BOOT_DIR, db_path: str = BOOT_DB) -> None:
+    with init_boot_db(db_path) as conn:
+        cur = conn.cursor()
+        for dirpath, _, files in os.walk(root):
+            for name in files:
+                fpath = os.path.join(dirpath, name)
+                try:
+                    with open(fpath, 'rb') as f:
+                        data = f.read()
+                except Exception:
+                    continue
+                rel = os.path.relpath(fpath, root)
+                checksum = sha256_data(data)
+                b64 = base64.b64encode(data).decode()
+                cur.execute(
+                    'INSERT OR REPLACE INTO boot_files (path, checksum, data) VALUES (?, ?, ?)',
+                    (rel, checksum, b64)
+                )
+        conn.commit()
+
+
+def restore_file(rel_path: str, data_b64: str, root: str = BOOT_DIR) -> None:
+    target = os.path.join(root, rel_path)
+    os.makedirs(os.path.dirname(target), exist_ok=True)
+    data = base64.b64decode(data_b64)
+    # Use dd to write the data for extra paranoia
+    subprocess.run(['dd', f'of={target}', 'bs=1M', 'status=none'], input=data, check=True)
+
+
+def verify_boot_files(root: str = BOOT_DIR, db_path: str = BOOT_DB) -> None:
+    with init_boot_db(db_path) as conn:
+        cur = conn.cursor()
+        rows = cur.execute('SELECT path, checksum, data FROM boot_files').fetchall()
+        for rel_path, checksum, data in rows:
+            target = os.path.join(root, rel_path)
+            cur_sum = sha256_file(target)
+            if cur_sum != checksum:
+                restore_file(rel_path, data, root)
+
+
+def main():
+    with init_boot_db() as conn:
+        cur = conn.cursor()
+        count = cur.execute('SELECT COUNT(*) FROM boot_files').fetchone()[0]
+    if count == 0:
+        backup_boot_files()
+    else:
+        verify_boot_files()
+
+
+if __name__ == '__main__':
+    main()

--- a/sentinelroot/db.py
+++ b/sentinelroot/db.py
@@ -5,6 +5,7 @@ from typing import List
 
 PROCESS_DB = os.path.join(os.path.dirname(__file__), 'processes.db')
 SIGNATURE_DB = os.path.join(os.path.dirname(__file__), 'signatures.db')
+BOOT_DB = os.path.join(os.path.dirname(__file__), 'boot_files.db')
 
 
 def init_process_db(db_path: str = PROCESS_DB) -> sqlite3.Connection:


### PR DESCRIPTION
## Summary
- add a boot partition protection tool that stores /boot files in sqlite and restores them when altered
- support boot integrity service installation
- document the new sentinelboot service

## Testing
- `python -m py_compile sentinelroot/boot_protect.py sentinelroot/db.py sentinelroot/sentinel.py`


------
https://chatgpt.com/codex/tasks/task_e_684592cbc01483238df5df9b289501af