### PR TITLE
Add boot partition image backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ A C implementation replicates the heuristic checks and logs results to syslog. B
 ```
 
 When run as root the script copies `sentinelroot` to `/usr/local/bin` and enables a `sentinelroot` systemd service.
-The installation also deploys `sentinelboot`, which verifies the contents of
-`/boot` on every startup and restores any modified files from a database.
+The installation also deploys `sentinelboot`, which backs up the entire
+`/boot` partition to a SQLite database on first run.  On every startup it
+verifies file checksums and, if any have changed, restores the whole
+partition from the stored image using ``dd``.
 
 ## External Scanner Integration
 

--- a/sentinelroot/boot_protect.py
+++ b/sentinelroot/boot_protect.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Boot partition integrity checker.
 
-On first run this script backs up files from /boot into a sqlite database
-as base64 encoded blobs. On subsequent runs it verifies the checksums of
-those files and restores any that changed using ``dd``.
+On first run this script backs up files from ``/boot`` into a SQLite
+database as base64 encoded blobs **and** stores a full image of the boot
+partition.  On subsequent runs it verifies the checksums of those files
+and if any mismatch it restores the entire partition using ``dd``.
 """
 import os
 import sqlite3
@@ -16,12 +17,42 @@ BOOT_DB = os.path.join(os.path.dirname(__file__), 'boot_files.db')
 BOOT_DIR = '/boot'
 
 
+def get_boot_device() -> str:
+    """Return the block device backing the boot partition."""
+    try:
+        out = subprocess.check_output(
+            ['findmnt', '-n', '-o', 'SOURCE', BOOT_DIR],
+            text=True,
+        )
+        dev = out.strip()
+        if dev:
+            return dev
+    except Exception:
+        pass
+    try:
+        with open('/etc/mtab') as f:
+            for line in f:
+                parts = line.split()
+                if len(parts) >= 2 and parts[1] == BOOT_DIR:
+                    return parts[0]
+    except Exception:
+        pass
+    return ''
+
+
 def init_boot_db(db_path: str = BOOT_DB) -> sqlite3.Connection:
     conn = sqlite3.connect(db_path)
     c = conn.cursor()
     c.execute(
         """CREATE TABLE IF NOT EXISTS boot_files (
             path TEXT PRIMARY KEY,
+            checksum TEXT,
+            data TEXT
+        )"""
+    )
+    c.execute(
+        """CREATE TABLE IF NOT EXISTS boot_image (
+            id INTEGER PRIMARY KEY,
             checksum TEXT,
             data TEXT
         )"""
@@ -62,6 +93,21 @@ def backup_boot_files(root: str = BOOT_DIR, db_path: str = BOOT_DB) -> None:
                     'INSERT OR REPLACE INTO boot_files (path, checksum, data) VALUES (?, ?, ?)',
                     (rel, checksum, b64)
                 )
+        # Also store a full partition image to allow complete restoration
+        dev = get_boot_device()
+        if dev:
+            try:
+                img = subprocess.check_output(
+                    ['dd', f'if={dev}', 'bs=1M', 'status=none']
+                )
+                img_b64 = base64.b64encode(img).decode()
+                checksum = sha256_data(img)
+                cur.execute(
+                    'INSERT OR REPLACE INTO boot_image (id, checksum, data) VALUES (1, ?, ?)',
+                    (checksum, img_b64)
+                )
+            except Exception:
+                pass
         conn.commit()
 
 
@@ -73,15 +119,29 @@ def restore_file(rel_path: str, data_b64: str, root: str = BOOT_DIR) -> None:
     subprocess.run(['dd', f'of={target}', 'bs=1M', 'status=none'], input=data, check=True)
 
 
+def restore_boot_partition(conn, root: str = BOOT_DIR) -> None:
+    """Restore the entire boot partition from the stored image."""
+    dev = get_boot_device()
+    if not dev:
+        return
+    cur = conn.cursor()
+    row = cur.execute('SELECT data FROM boot_image WHERE id=1').fetchone()
+    if not row:
+        return
+    data = base64.b64decode(row[0])
+    subprocess.run(['dd', f'of={dev}', 'bs=1M', 'status=none'], input=data, check=True)
+
+
 def verify_boot_files(root: str = BOOT_DIR, db_path: str = BOOT_DB) -> None:
     with init_boot_db(db_path) as conn:
         cur = conn.cursor()
-        rows = cur.execute('SELECT path, checksum, data FROM boot_files').fetchall()
-        for rel_path, checksum, data in rows:
+        rows = cur.execute('SELECT path, checksum FROM boot_files').fetchall()
+        for rel_path, checksum in rows:
             target = os.path.join(root, rel_path)
             cur_sum = sha256_file(target)
             if cur_sum != checksum:
-                restore_file(rel_path, data, root)
+                restore_boot_partition(conn, root)
+                break
 
 
 def main():


### PR DESCRIPTION
## Summary
- expand sentinelboot to capture full /boot partition using dd and store it in sqlite
- restore entire boot partition from saved image if file checksums change
- document the new behaviour in README

## Testing
- `python -m py_compile sentinelroot/boot_protect.py`
- `python -m compileall sentinelroot`

------
https://chatgpt.com/codex/tasks/task_e_68459d6bb3948323bd1febb8228d0515