### PR TITLE
Enable background ML training on launch

### DIFF
--- a/sentinelroot/train.py
+++ b/sentinelroot/train.py
@@ -11,18 +11,11 @@ DEFAULT_URLS = [
 ]
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Train signature classifier")
-    parser.add_argument('--urls', nargs='*', default=DEFAULT_URLS,
-                        help='CSV or ZIP URLs providing a signature dataset')
-    parser.add_argument('--model-path', default='signature_model.joblib')
-    parser.add_argument('--binary-dataset', help='CSV of extracted binary features for XGBoost model')
-    parser.add_argument('--cv', type=int, default=5,
-                        help='Number of cross validation folds')
-    args = parser.parse_args()
-
+def train_models(urls=DEFAULT_URLS, model_path='signature_model.joblib',
+                 binary_dataset=None, cv=5):
+    """Train the ML models and store them on disk."""
     clf = SignatureClassifier()
-    df = clf.fetch_dataset(args.urls)
+    df = clf.fetch_dataset(urls)
 
     # Store signatures in SQLite for faster lookup by the main heuristic
     with init_signature_db(SIGNATURE_DB) as conn:
@@ -33,31 +26,45 @@ def main():
             )
         conn.commit()
 
-    # Perform cross validation using a pipeline so the vectorizer is
-    # fitted inside each fold. This provides a more realistic estimate
-    # of model performance.
     pipeline = make_pipeline(clf.vectorizer, clf.clf)
     scores = cross_val_score(pipeline, df['signature'], df['label'],
-                             cv=args.cv, scoring='f1')
+                             cv=cv, scoring='f1')
     print(f"Cross-validation F1: {scores.mean():.3f} ± {scores.std():.3f}")
 
-    # Fit on the full dataset and save the resulting model
     pipeline.fit(df['signature'], df['label'])
     clf.vectorizer = pipeline.named_steps['tfidfvectorizer']
     clf.clf = pipeline.named_steps['randomforestclassifier']
-    clf.save(args.model_path)
-    print(f"Model saved to {args.model_path}")
+    clf.save(model_path)
+    print(f"Model saved to {model_path}")
 
-    if args.binary_dataset:
-        bdf = pd.read_csv(args.binary_dataset)
+    if binary_dataset:
+        bdf = pd.read_csv(binary_dataset)
         X = bdf.drop('label', axis=1)
         y = bdf['label']
         s_clf = StaticFeatureClassifier()
-        scores = cross_val_score(s_clf.clf, X, y, cv=args.cv, scoring='f1')
+        scores = cross_val_score(s_clf.clf, X, y, cv=cv, scoring='f1')
         print(f"Static features F1: {scores.mean():.3f} ± {scores.std():.3f}")
         s_clf.train(X, y)
         s_clf.save('static_model.joblib')
         print("Static model saved to static_model.joblib")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train signature classifier")
+    parser.add_argument('--urls', nargs='*', default=DEFAULT_URLS,
+                        help='CSV or ZIP URLs providing a signature dataset')
+    parser.add_argument('--model-path', default='signature_model.joblib')
+    parser.add_argument('--binary-dataset', help='CSV of extracted binary features for XGBoost model')
+    parser.add_argument('--cv', type=int, default=5,
+                        help='Number of cross validation folds')
+    args = parser.parse_args()
+
+    train_models(
+        urls=args.urls,
+        model_path=args.model_path,
+        binary_dataset=args.binary_dataset,
+        cv=args.cv,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expose `train_models` helper for programmatic training
- start model training in a background thread when running sentinelroot
- log a message once training completes

## Testing
- `python -m py_compile sentinelroot/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a28e39f08323b8d714a8a1956047