### PR TITLE
Enhance tool integrity checks and IPS features

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ partition from the stored image using ``dd``.
 ## External Scanner Integration
 
 On its first execution the Python module attempts to run [rkhunter](http://rkhunter.sourceforge.net/), [chkrootkit](http://www.chkrootkit.org/), [lynis](https://cisofy.com/lynis/), [maldet](https://www.rfxn.com/projects/linux-malware-detect/), [ClamAV](https://www.clamav.net/) and the [OSSEC](https://www.ossec.net/) rootcheck when these tools are installed. Output from these scanners is sent to syslog via the `logger` command and can be reviewed with `dmesg` or by inspecting `/var/log/syslog`.
+Before each scanner runs its binary hash is compared against a checksum stored in
+`tools.db`.  When a mismatch is detected the tool is automatically reinstalled
+from the package repository and the new checksum recorded.  This guards against
+tampering of the external scanners themselves.
 
 ## Training the ML Heuristic
 
@@ -118,7 +122,7 @@ database updated, which looks like the following:
 
 ## Project Goals
 
-This repository contains only a minimal proof-of-concept. The broader project goal is a full detection engine capable of analysing static binary features, kernel integrity hooks, system behaviour, persistence techniques and network patterns. The latest prototype now inspects systemd services, monitors network connections against a list of malicious IPs and can analyse static binary features using a gradient boosting model powered by **XGBoost** when available. Machine learning models complement rule-based heuristics for higher accuracy.
+This repository contains only a minimal proof-of-concept. The broader project goal is a full detection engine capable of analysing static binary features, kernel integrity hooks, system behaviour, persistence techniques and network patterns. The latest prototype now inspects systemd services, monitors network connections against a list of malicious IPs and can analyse static binary features using a gradient boosting model powered by **XGBoost** when available. Machine learning models complement rule-based heuristics for higher accuracy. The current release also applies this malicious IP list as an **IPS** rule set by inserting `iptables` drop rules for each address found in `malicious_ips.json`.
 
 ## Upcoming Features
 

--- a/sentinelroot/db.py
+++ b/sentinelroot/db.py
@@ -6,6 +6,7 @@ from typing import List
 PROCESS_DB = os.path.join(os.path.dirname(__file__), 'processes.db')
 SIGNATURE_DB = os.path.join(os.path.dirname(__file__), 'signatures.db')
 BOOT_DB = os.path.join(os.path.dirname(__file__), 'boot_files.db')
+TOOLS_DB = os.path.join(os.path.dirname(__file__), 'tools.db')
 
 
 def init_process_db(db_path: str = PROCESS_DB) -> sqlite3.Connection:
@@ -13,6 +14,20 @@ def init_process_db(db_path: str = PROCESS_DB) -> sqlite3.Connection:
     c = conn.cursor()
     c.execute(
         "CREATE TABLE IF NOT EXISTS process_checksums (path TEXT PRIMARY KEY, checksum TEXT, last_seen INTEGER)"
+    )
+    conn.commit()
+    return conn
+
+
+def init_tool_db(db_path: str = TOOLS_DB) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    c = conn.cursor()
+    c.execute(
+        """CREATE TABLE IF NOT EXISTS tool_checksums (
+            name TEXT PRIMARY KEY,
+            path TEXT,
+            checksum TEXT
+        )"""
     )
     conn.commit()
     return conn
@@ -38,6 +53,16 @@ def store_process(path: str, checksum: str, db_path: str = PROCESS_DB):
         conn.commit()
 
 
+def store_tool_checksum(name: str, path: str, checksum: str, db_path: str = TOOLS_DB):
+    with init_tool_db(db_path) as conn:
+        c = conn.cursor()
+        c.execute(
+            "INSERT OR REPLACE INTO tool_checksums (name, path, checksum) VALUES (?, ?, ?)",
+            (name, path, checksum),
+        )
+        conn.commit()
+
+
 def find_paths_by_checksum(checksum: str, db_path: str = PROCESS_DB) -> List[str]:
     with init_process_db(db_path) as conn:
         c = conn.cursor()
@@ -45,6 +70,26 @@ def find_paths_by_checksum(checksum: str, db_path: str = PROCESS_DB) -> List[str
             "SELECT path FROM process_checksums WHERE checksum=?", (checksum,)
         ).fetchall()
         return [r[0] for r in rows]
+
+
+def get_tool_checksum(name: str, db_path: str = TOOLS_DB) -> str:
+    with init_tool_db(db_path) as conn:
+        c = conn.cursor()
+        row = c.execute(
+            "SELECT checksum FROM tool_checksums WHERE name=?",
+            (name,),
+        ).fetchone()
+        return row[0] if row else ''
+
+
+def get_tool_path(name: str, db_path: str = TOOLS_DB) -> str:
+    with init_tool_db(db_path) as conn:
+        c = conn.cursor()
+        row = c.execute(
+            "SELECT path FROM tool_checksums WHERE name=?",
+            (name,),
+        ).fetchone()
+        return row[0] if row else ''
 
 
 def load_signatures(db_path: str = SIGNATURE_DB) -> List[str]:


### PR DESCRIPTION
## Summary
- track external scanner checksums in `tools.db`
- verify tool checksum before running scanners and reinstall if mismatch
- proactively block IPs from `malicious_ips.json`
- document new IPS and integrity behavior in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `cmake ../src && make`

------
https://chatgpt.com/codex/tasks/task_e_6845a4cb27c88323ada008fd3278b5db