### PR TITLE
Add dmesg TUI viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ python -m sentinelroot.tui
 Press `q` to exit the interface. This provides the same heuristic report as the
 standard Python script but in a fullscreen terminal view.
 
+A separate TUI shows the kernel ring buffer from `dmesg` with colorized log
+levels and updates every second:
+
+```bash
+python -m sentinelroot.dmesg_viewer
+```
+
+Use the arrow keys or PageUp/PageDown to scroll.  Press `q` to exit.
+
 ## C Service
 
 A C implementation replicates the heuristic checks and logs results to syslog. Build and install it using:`install.sh`:

--- a/sentinelroot/dmesg_viewer.py
+++ b/sentinelroot/dmesg_viewer.py
@@ -1,0 +1,99 @@
+import curses
+import subprocess
+import time
+from typing import List, Dict
+
+
+def read_dmesg_lines() -> List[str]:
+    """Return the full dmesg output split into lines."""
+    try:
+        out = subprocess.check_output(
+            ["dmesg", "-x", "-T", "--color=never"],
+            text=True,
+        )
+        return out.splitlines()
+    except Exception:
+        return []
+
+
+LEVEL_PAIRS: Dict[str, int] = {}
+
+
+def init_colors() -> None:
+    curses.start_color()
+    curses.use_default_colors()
+    pairs = {
+        "emerg": curses.COLOR_RED,
+        "alert": curses.COLOR_RED,
+        "crit": curses.COLOR_MAGENTA,
+        "err": curses.COLOR_RED,
+        "warn": curses.COLOR_YELLOW,
+        "notice": curses.COLOR_CYAN,
+        "info": curses.COLOR_WHITE,
+        "debug": curses.COLOR_GREEN,
+    }
+    for idx, (level, color) in enumerate(pairs.items(), start=1):
+        curses.init_pair(idx, color, -1)
+        LEVEL_PAIRS[level] = idx
+
+
+def parse_level(line: str) -> str:
+    parts = line.split(":", 2)
+    if len(parts) >= 2:
+        return parts[1].strip()
+    return "info"
+
+
+def draw_lines(stdscr, lines: List[str], scroll: int) -> None:
+    height, width = stdscr.getmaxyx()
+    visible = lines[scroll : scroll + height]
+    for idx, line in enumerate(visible):
+        level = parse_level(line)
+        pair = curses.color_pair(LEVEL_PAIRS.get(level, LEVEL_PAIRS["info"]))
+        stdscr.addnstr(idx, 0, line, width - 1, pair)
+
+    # scrollbar
+    total = len(lines)
+    if total > height:
+        bar_height = max(1, height * height // total)
+        bar_pos = scroll * (height - bar_height) // (total - height)
+        for i in range(height):
+            attr = curses.A_REVERSE if bar_pos <= i < bar_pos + bar_height else curses.A_DIM
+            stdscr.addch(i, width - 1, " ", attr)
+
+
+def main(stdscr) -> None:
+    curses.curs_set(0)
+    stdscr.nodelay(True)
+    init_colors()
+    lines = read_dmesg_lines()
+    scroll = max(0, len(lines) - curses.LINES)
+    last_refresh = time.time()
+    while True:
+        now = time.time()
+        if now - last_refresh >= 1:
+            lines = read_dmesg_lines()
+            if scroll > len(lines) - curses.LINES:
+                scroll = max(0, len(lines) - curses.LINES)
+            last_refresh = now
+
+        stdscr.erase()
+        draw_lines(stdscr, lines, scroll)
+        stdscr.refresh()
+
+        ch = stdscr.getch()
+        if ch == ord("q"):
+            break
+        elif ch == curses.KEY_UP:
+            scroll = max(0, scroll - 1)
+        elif ch == curses.KEY_DOWN:
+            scroll = min(max(len(lines) - curses.LINES, 0), scroll + 1)
+        elif ch == curses.KEY_NPAGE:
+            scroll = min(max(len(lines) - curses.LINES, 0), scroll + curses.LINES)
+        elif ch == curses.KEY_PPAGE:
+            scroll = max(0, scroll - curses.LINES)
+        time.sleep(0.05)
+
+
+if __name__ == "__main__":
+    curses.wrapper(main)


### PR DESCRIPTION
## Summary
- provide a new `dmesg_viewer` curses tool
- document new log viewer in README

## Testing
- `python -m py_compile sentinelroot/tui.py sentinelroot/dmesg_viewer.py`

------
https://chatgpt.com/codex/tasks/task_e_684639312d7c8323beaa77be1b8d0363