### PR TITLE
Improve dmesg viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Press `q` to exit the interface. This provides the same heuristic report as the
 standard Python script but in a fullscreen terminal view.
 
 A separate TUI shows the kernel ring buffer from `dmesg` with colorized log
-levels and updates every second:
+levels, filtered to the `sentinelroot` tag, and updates every second with
+automatic scrolling when new log entries arrive:
 
 ```bash
 python -m sentinelroot.dmesg_viewer

--- a/sentinelroot/dmesg_viewer.py
+++ b/sentinelroot/dmesg_viewer.py
@@ -3,15 +3,17 @@ import subprocess
 import time
 from typing import List, Dict
 
+LOG_TAG = "sentinelroot"
+
 
 def read_dmesg_lines() -> List[str]:
-    """Return the full dmesg output split into lines."""
+    """Return dmesg lines related to SentinelRoot."""
     try:
         out = subprocess.check_output(
             ["dmesg", "-x", "-T", "--color=never"],
             text=True,
         )
-        return out.splitlines()
+        return [line for line in out.splitlines() if LOG_TAG in line]
     except Exception:
         return []
 
@@ -72,8 +74,11 @@ def main(stdscr) -> None:
     while True:
         now = time.time()
         if now - last_refresh >= 1:
+            prev_len = len(lines)
             lines = read_dmesg_lines()
-            if scroll > len(lines) - curses.LINES:
+            if len(lines) > prev_len and scroll >= prev_len - curses.LINES:
+                scroll = max(0, len(lines) - curses.LINES)
+            elif scroll > len(lines) - curses.LINES:
                 scroll = max(0, len(lines) - curses.LINES)
             last_refresh = now
 


### PR DESCRIPTION
## Summary
- filter `dmesg_viewer` output so it only displays logs tagged with `sentinelroot`
- keep the display scrolled to the latest logs while new entries are appended
- clarify README usage of the viewer

## Testing
- `python -m py_compile sentinelroot/dmesg_viewer.py`
- `python -m compileall -q sentinelroot`
- `python -m compileall -q README.md sentinelroot/dmesg_viewer.py`


------
https://chatgpt.com/codex/tasks/task_e_68463bd697788323ae57a63c51447eb3