### PR TITLE
Ensure services run python modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ Use the arrow keys or PageUp/PageDown to scroll.  Press `q` to exit.
 The provided `install.sh` script installs the Python heuristics to
 `/usr/local/share/sentinelroot` and configures a `sentinelroot` systemd
 service. The service runs the `sentinel.py` module with `python3` and logs
-results to syslog. The installer also deploys `sentinelboot`, which backs up the
-entire `/boot` partition to a SQLite database on first run. On every boot the
-script verifies file checksums and restores the partition using ``dd`` when any
+results to syslog. The installer also sets up a `sentinelboot` service that
+runs the `boot_protect.py` module with `python3`. On first boot the script
+backs up the entire `/boot` partition to a SQLite database. On every boot the
+checksums are verified and the partition is restored with ``dd`` whenever any
 changes are detected.
 
 ## External Scanner Integration

--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,14 @@ fi
 if [ "$(id -u)" = "0" ]; then
     mkdir -p /usr/local/share/sentinelroot
     cp -r sentinelroot/* /usr/local/share/sentinelroot/
-    install -m 755 sentinelroot/boot_protect.py /usr/local/bin/sentinelboot
+    # Copy the boot protection script but do not install a separate
+    # executable wrapper so the service always invokes the Python code.
+    install -m 755 sentinelroot/boot_protect.py /usr/local/share/sentinelroot/
+    # Remove any previously installed compiled version of sentinelboot
+    # that may exist from older releases.
+    if [ -f /usr/local/bin/sentinelboot ]; then
+        rm -f /usr/local/bin/sentinelboot
+    fi
     install -m 644 sentinelroot.service /etc/systemd/system/
     install -m 644 sentinelboot.service /etc/systemd/system/
     systemctl daemon-reload

--- a/sentinelboot.service
+++ b/sentinelboot.service
@@ -4,7 +4,9 @@ After=local-fs.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/local/bin/sentinelboot
+# Explicitly run the Python implementation to avoid
+# any stale compiled binaries.
+ExecStart=/usr/bin/python3 /usr/local/share/sentinelroot/boot_protect.py
 
 [Install]
 WantedBy=multi-user.target

--- a/sentinelroot.service
+++ b/sentinelroot.service
@@ -3,7 +3,10 @@ Description=SentinelRoot Heuristic Monitor
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python3 /usr/local/share/sentinelroot/sentinel.py
+# Run the Python module directly to prevent using any
+# previously compiled binaries that may exist.
+Environment="PYTHONPATH=/usr/local/share"
+ExecStart=/usr/bin/python3 -m sentinelroot.sentinel
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
## Summary
- update systemd service files to run Python modules directly
- adjust install script to remove any compiled sentinelboot binary
- clarify README about sentinelboot service

## Testing
- `python -m py_compile sentinelroot/*.py`
- `shellcheck install.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68464a22abbc8323a785dcc1bc4202a3