### PR TITLE
Ensure uninstall securely shreds SQLite DBs

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -21,6 +21,14 @@ for svc in "${SERVICES[@]}"; do
 done
 systemctl daemon-reload
 
+# Securely shred SQLite databases before removing directories
+DB_DIRS=(/usr/local/share/sentinelroot /var/lib/sentinelroot)
+for dir in "${DB_DIRS[@]}"; do
+    if [ -d "$dir" ]; then
+        find "$dir" -type f -name '*.db' -exec shred -fuxzn7 {} \;
+    fi
+done
+
 rm -rf /usr/local/share/sentinelroot
 rm -rf /var/lib/sentinelroot
 rm -f /usr/local/bin/sentinelboot


### PR DESCRIPTION
## Summary
- shred SQLite databases before removing sentinelroot directories

## Testing
- `shellcheck uninstall.sh`
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68464eb72b9883239e0c53014c57d24a