### PR TITLE
Install sentinelroot as Python package

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ Run the provided `install.sh` script to install the Python service and all
 dependencies. The script detects `apt`, `yum`, `zypper` or `aptitude` and uses
 the available package manager to install `rkhunter`, `chkrootkit`, `lynis`,
 `maldet`, `clamav` and `ossec-hids` along with the Python modules from
-`requirements.txt`.
+`requirements.txt`. The installer also registers `sentinelroot` as a Python
+package so the commands `python -m sentinelroot.tui` and
+`python -m sentinelroot.dmesg_viewer` work from any directory.
 
 All detections from the Python heuristics are automatically sent to syslog via
 the `logger` command using the tag `sentinelroot`.  Messages can be inspected
@@ -94,6 +96,9 @@ automatic scrolling when new log entries arrive:
 ```bash
 python -m sentinelroot.dmesg_viewer
 ```
+
+These module invocations work from any directory once the installer has
+registered `sentinelroot` as a Python package.
 
 Log lines are highlighted based on their syslog severity so that warnings and
 errors are easy to spot while scrolling.

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,9 @@ if [ "$(id -u)" = "0" ]; then
         echo "No supported package manager found. Install $PKGS manually." >&2
     fi
     pip3 install -r requirements.txt
+    # Register the Python package so modules can be executed with
+    # "python -m sentinelroot.*" from any directory.
+    pip3 install --upgrade .
 else
     echo "Run as root to install system packages."
 fi
@@ -23,9 +26,6 @@ fi
 if [ "$(id -u)" = "0" ]; then
     mkdir -p /usr/local/share/sentinelroot
     cp -r sentinelroot/* /usr/local/share/sentinelroot/
-    # Copy the boot protection script but do not install a separate
-    # executable wrapper so the service always invokes the Python code.
-    install -m 755 sentinelroot/boot_protect.py /usr/local/share/sentinelroot/
     # Remove any previously installed compiled version of sentinelboot
     # that may exist from older releases.
     if [ -f /usr/local/bin/sentinelboot ]; then

--- a/sentinelboot.service
+++ b/sentinelboot.service
@@ -6,7 +6,7 @@ After=local-fs.target
 Type=oneshot
 # Explicitly run the Python implementation to avoid
 # any stale compiled binaries.
-ExecStart=/usr/bin/python3 /usr/local/share/sentinelroot/boot_protect.py
+ExecStart=/usr/bin/python3 -m sentinelroot.boot_protect
 
 [Install]
 WantedBy=multi-user.target

--- a/sentinelroot.service
+++ b/sentinelroot.service
@@ -5,7 +5,6 @@ Description=SentinelRoot Heuristic Monitor
 Type=simple
 # Run the Python module directly to prevent using any
 # previously compiled binaries that may exist.
-Environment="PYTHONPATH=/usr/local/share"
 ExecStart=/usr/bin/python3 -m sentinelroot.sentinel
 Restart=on-failure
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="sentinelroot",
+    version="0.1.0",
+    description="SentinelRoot heuristic monitoring tools",
+    packages=find_packages(),
+    include_package_data=True,
+    package_data={"sentinelroot": ["malicious_ips.json"]},
+)

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -37,6 +37,7 @@ rm -f /var/log/sentinel_update.log
 
 if command -v pip3 >/dev/null; then
     xargs -r pip3 uninstall -y < requirements.txt || true
+    pip3 uninstall -y sentinelroot || true
 fi
 
 logger -t sentinelroot "SentinelRoot uninstalled successfully"


### PR DESCRIPTION
## Summary
- add `setup.py` to package sentinelroot
- install package in `install.sh`
- uninstall package via `uninstall.sh`
- drop PYTHONPATH override from service and run boot protection by module
- document new behaviour that modules can run from any directory

## Testing
- `python3 -m compileall -q sentinelroot`
- `python3 -m py_compile setup.py`


------
https://chatgpt.com/codex/tasks/task_e_684650be8c28832398634c49d341829e