### PR TITLE
Update install script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ Run the provided `install.sh` script to install the Python service and all
 dependencies. The script detects `apt`, `yum`, `zypper` or `aptitude` and uses
 the available package manager to install `rkhunter`, `chkrootkit`, `lynis`,
 `maldet`, `clamav` and `ossec-hids` along with the Python modules from
-`requirements.txt`. The installer also registers `sentinelroot` as a Python
-package so the commands `python -m sentinelroot.tui` and
+`requirements.txt`.  During installation the script calls `python3 -m pip
+install --upgrade .` which executes `setup.py` and registers the
+`sentinelroot` package so the commands `python -m sentinelroot.tui` and
 `python -m sentinelroot.dmesg_viewer` work from any directory.
 
 All detections from the Python heuristics are automatically sent to syslog via

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-set -e
+# Exit immediately on error, treat unset variables as an error and
+# propagate failures through pipes so that the script halts when any
+# step fails.
+set -euo pipefail
 PKGS="rkhunter chkrootkit lynis maldet ossec-hids clamav clamav-freshclam"
 
 if [ "$(id -u)" = "0" ]; then
@@ -15,10 +18,10 @@ if [ "$(id -u)" = "0" ]; then
     else
         echo "No supported package manager found. Install $PKGS manually." >&2
     fi
-    pip3 install -r requirements.txt
+    python3 -m pip install -r requirements.txt
     # Register the Python package so modules can be executed with
     # "python -m sentinelroot.*" from any directory.
-    pip3 install --upgrade .
+    python3 -m pip install --upgrade .
 else
     echo "Run as root to install system packages."
 fi


### PR DESCRIPTION
## Summary
- make installation pipeline strict with `set -euo pipefail`
- install Python requirements using `python3 -m pip`
- document how `install.sh` registers the package via setup.py

## Testing
- `pip3 check`
- `python3 -m py_compile sentinelroot/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6846547e1808832386b640d3d0f5ccbf