### PR TITLE
Ensure services run as root

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,12 @@ Use the arrow keys or PageUp/PageDown to scroll.  Press `q` to exit.
 The provided `install.sh` script installs the Python heuristics to
 `/usr/local/share/sentinelroot` and configures a `sentinelroot` systemd
 service. The service runs the `sentinel.py` module with `python3` and logs
-results to syslog. The installer also sets up a `sentinelboot` service that
+results to syslog. The unit file explicitly specifies `User=root` so the
+heuristics have the permissions required to inspect system resources. The
+installer also sets up a `sentinelboot` service that
 runs the `boot_protect.py` module with `python3`. On first boot the script
-backs up the entire `/boot` partition to a SQLite database. On every boot the
+backs up the entire `/boot` partition to a SQLite database. This service also
+executes as `root` so it can access and restore the boot partition. On every boot the
 checksums are verified and the partition is restored with ``dd`` whenever any
 changes are detected.
 

--- a/sentinelboot.service
+++ b/sentinelboot.service
@@ -4,6 +4,9 @@ After=local-fs.target
 
 [Service]
 Type=oneshot
+# Explicitly run as root since boot partition backups require
+# administrative permissions
+User=root
 # Explicitly run the Python implementation to avoid
 # any stale compiled binaries.
 ExecStart=/usr/bin/python3 -m sentinelroot.boot_protect

--- a/sentinelroot.service
+++ b/sentinelroot.service
@@ -3,6 +3,8 @@ Description=SentinelRoot Heuristic Monitor
 
 [Service]
 Type=simple
+# Run as root to ensure access to system resources
+User=root
 # Run the Python module directly to prevent using any
 # previously compiled binaries that may exist.
 ExecStart=/usr/bin/python3 -m sentinelroot.sentinel


### PR DESCRIPTION
## Summary
- update systemd units to include `User=root`
- document root execution in README

## Testing
- `python3 -m py_compile sentinelroot/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68466127c0288323b6efdfdc19c9e4d3