### PR TITLE
Fix logger option parsing

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -47,7 +47,7 @@ EOF
     echo "Installed sentinelroot and enabled service"
     echo "Cron job added for weekly signature updates"
     # Notify user of successful installation and how to view logs
-    logger -t sentinelroot "SentinelRoot installation successful"
+    logger -t sentinelroot -- "SentinelRoot installation successful"
     echo "Installation complete! SentinelRoot is now protecting your system."
     echo "Check logs with 'journalctl -t sentinelroot' or in /var/log/syslog"
     echo "Upcoming features: improved automation around signature updates and ML model retraining, and scheduled rkhunter scans."

--- a/sentinelroot/sentinel.py
+++ b/sentinelroot/sentinel.py
@@ -64,6 +64,7 @@ def start_background_training() -> None:
                     "user.notice",
                     "-t",
                     LOG_TAG,
+                    "--",
                     "ML training complete - model ready",
                 ],
                 check=False,
@@ -76,6 +77,7 @@ def start_background_training() -> None:
                     "user.err",
                     "-t",
                     LOG_TAG,
+                    "--",
                     f"ML training failed: {e}",
                 ],
                 check=False,
@@ -104,6 +106,7 @@ class SentinelReport:
                 f"user.{level}",
                 "-t",
                 LOG_TAG,
+                "--",
                 message,
             ], check=False)
         except Exception:
@@ -602,7 +605,7 @@ def _log_lines(prefix: str, lines: List[str]):
     for line in lines:
         try:
             subprocess.run(
-                ["logger", "-p", "user.debug", "-t", prefix, line], check=True
+                ["logger", "-p", "user.debug", "-t", prefix, "--", line], check=True
             )
         except Exception:
             pass

--- a/sentinelroot/update_signatures.py
+++ b/sentinelroot/update_signatures.py
@@ -31,6 +31,7 @@ def main():
                 "user.err",
                 "-t",
                 "sentinelroot",
+                "--",
                 msg,
             ], check=False)
         except Exception:

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -6,7 +6,7 @@ if [ "$(id -u)" != "0" ]; then
     exit 1
 fi
 
-logger -t sentinelroot "Starting SentinelRoot uninstallation"
+logger -t sentinelroot -- "Starting SentinelRoot uninstallation"
 
 SERVICES=(sentinelroot.service sentinelboot.service)
 for svc in "${SERVICES[@]}"; do
@@ -40,5 +40,5 @@ if command -v pip3 >/dev/null; then
     pip3 uninstall -y sentinelroot || true
 fi
 
-logger -t sentinelroot "SentinelRoot uninstalled successfully"
+logger -t sentinelroot -- "SentinelRoot uninstalled successfully"
 echo "Uninstallation complete. External scanner tools remain installed."


### PR DESCRIPTION
## Summary
- ensure logger messages are separated from options with `--`
- handle external scanner logs that may start with dashes
- update signature update script
- adjust install/uninstall scripts

## Testing
- `python -m py_compile sentinelroot/*.py`
- `bash -n install.sh`
- `bash -n uninstall.sh`

------
https://chatgpt.com/codex/tasks/task_e_68466414fb0483238b96ddfb4b146050