### PR TITLE
Keep sentinel service running

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,14 @@ removal so you can verify the cleanup with `journalctl -t sentinelroot`.
 ```bash
 pip install -r requirements.txt
 python -m sentinelroot.sentinel
+python -m sentinelroot.sentinel --loop  # continuous monitoring
 ```
 
-The script prints a simple report with any suspicious findings. When run as
-root it also attempts to kill processes or unload kernel modules whose names
-match known malicious signatures. Elevated permissions may therefore be
-required for full functionality.
+Running the module once prints a simple report with any suspicious findings.
+When executed with `--loop` the checks repeat at one-minute intervals until
+interrupted. When run as root the script may kill processes or unload kernel
+modules whose names match known malicious signatures, so elevated permissions
+can be required for full functionality.
 
 ## Command Line TUI
 
@@ -112,8 +114,9 @@ Use the arrow keys or PageUp/PageDown to scroll.  Press `q` to exit.
 
 The provided `install.sh` script installs the Python heuristics to
 `/usr/local/share/sentinelroot` and configures a `sentinelroot` systemd
-service. The service runs the `sentinel.py` module with `python3` and logs
-results to syslog. The unit file explicitly specifies `User=root` so the
+service. The service runs the `sentinel.py` module in looping mode
+(`--loop`) with `python3` so it remains active and systemd restarts it on
+failure. The unit file explicitly specifies `User=root` so the
 heuristics have the permissions required to inspect system resources. The
 installer also sets up a `sentinelboot` service that
 runs the `boot_protect.py` module with `python3`. On first boot the script

--- a/sentinelroot.service
+++ b/sentinelroot.service
@@ -7,7 +7,7 @@ Type=simple
 User=root
 # Run the Python module directly to prevent using any
 # previously compiled binaries that may exist.
-ExecStart=/usr/bin/python3 -m sentinelroot.sentinel
+ExecStart=/usr/bin/python3 -m sentinelroot.sentinel --loop
 Restart=on-failure
 
 [Install]

--- a/sentinelroot/sentinel.py
+++ b/sentinelroot/sentinel.py
@@ -7,6 +7,7 @@ import sqlite3
 import hashlib
 import time
 import json
+import argparse
 
 # Simple lists of known malicious signatures. These can be extended or
 # loaded from an external source in the future.
@@ -703,10 +704,30 @@ def run_heuristics() -> SentinelReport:
     return report
 
 def main():
+    parser = argparse.ArgumentParser(
+        description="SentinelRoot heuristic scanner"
+    )
+    parser.add_argument(
+        "--loop",
+        action="store_true",
+        help="Run continuously and repeat checks",
+    )
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=60,
+        help="Seconds to sleep between scans when looping",
+    )
+    args = parser.parse_args()
+
     start_background_training()
-    report = run_heuristics()
-    print("SentinelRoot Heuristic Report")
-    print(report.summary())
+    while True:
+        report = run_heuristics()
+        print("SentinelRoot Heuristic Report")
+        print(report.summary())
+        if not args.loop:
+            break
+        time.sleep(max(args.interval, 1))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add optional `--loop` mode to `sentinelroot.sentinel`
- make systemd unit call the module with `--loop`
- document new looping behaviour in README

## Testing
- `python -m py_compile sentinelroot/sentinel.py`

------
https://chatgpt.com/codex/tasks/task_e_68466bf4960c83238006b28599235cfc