### PR TITLE
Start services after install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,8 @@ if [ "$(id -u)" = "0" ]; then
     systemctl daemon-reload
     systemctl enable sentinelroot.service
     systemctl enable sentinelboot.service
+    systemctl start sentinelroot.service
+    systemctl start sentinelboot.service
     # weekly signature update cron job
     cat >/etc/cron.d/sentinelroot_update <<'EOF'
 0 3 * * 0 root /usr/bin/python3 -m sentinelroot.update_signatures >> /var/log/sentinel_update.log 2>&1


### PR DESCRIPTION
## Summary
- start `sentinelroot` and `sentinelboot` after enabling the units

## Testing
- `python3 -m py_compile sentinelroot/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684671fafc0c832398509e426ec8646f