### PR TITLE
Fix curses scrollbar draw error

### DIFF
--- a/sentinelroot/tui.py
+++ b/sentinelroot/tui.py
@@ -17,7 +17,11 @@ def draw_lines(stdscr, lines, scroll):
         bar_pos = scroll * (height - bar_height) // (total - height)
         for i in range(height):
             attr = curses.A_REVERSE if bar_pos <= i < bar_pos + bar_height else curses.A_DIM
-            stdscr.addch(i, width - 1, ' ', attr)
+            if width > 0:
+                try:
+                    stdscr.addch(i, width - 1, ' ', attr)
+                except curses.error:
+                    pass
 
 
 def append_report(lines):


### PR DESCRIPTION
## Summary
- fix crash writing to the lower-right corner in sentinelroot.tui

## Testing
- `python -m py_compile sentinelroot/tui.py`

------
https://chatgpt.com/codex/tasks/task_e_6846762a205c8323a7b86d5903070484